### PR TITLE
Update google-play.mdx

### DIFF
--- a/docs/server-notifications/google-play.mdx
+++ b/docs/server-notifications/google-play.mdx
@@ -100,3 +100,7 @@ message, otherwise the message will keep trying to be sent.
 
 Test messages are logged by LIAP out of the box, so you can see the messages
 in the logs.
+
+:::info Info:::
+**Test card, always approves" is not a pending transaction which is why no notifications are sent today ** https://stackoverflow.com/questions/65029988/android-real-time-developer-notification-for-one-time-purchase-is-half-working
+:::


### PR DESCRIPTION
Test card, always approves" is not a pending transaction which is why no notifications are sent today