### PR TITLE
Updated documentation for new App Store Credentials location

### DIFF
--- a/docs/credentials/app-store.mdx
+++ b/docs/credentials/app-store.mdx
@@ -25,6 +25,6 @@ Once you have your shared secret, you can add it to the configuration file.
 ```php title="config/liap.php"
 [
   // Other configuration options are omitted for brevity.
-  'appstore_password' => env('APPSTORE_PASSWORD', '<your shared secret>'),
+  'appstore_password' => env('APPSTORE_PASSWORD', ''), // Your shared secret
 ];
 ```

--- a/docs/credentials/app-store.mdx
+++ b/docs/credentials/app-store.mdx
@@ -12,7 +12,7 @@ The application password or secret it used to authenticate LIAP with the App Sto
 1. Go to [App Store Connect](https://appstoreconnect.apple.com/).
 2. Log in with your Apple ID.
 3. Click on the **My Apps** and select the app you want to configure.
-4. Select **Subscriptions** under the **Features** section from the **left** menu.
+4. Select **App Information** under the **General** section from the **left** menu.
 5. Select **Manage** under the **App-Specific Share Secret** section from the **right** side.
 ![](/img/credentials/features-section.png)
 6. Generate and copy your shared secret.
@@ -25,6 +25,6 @@ Once you have your shared secret, you can add it to the configuration file.
 ```php title="config/liap.php"
 [
   // Other configuration options are omitted for brevity.
-  'appstore_password' => '<your shared secret>',
+  'appstore_password' => env('APPSTORE_PASSWORD', '<your shared secret>'),
 ];
 ```


### PR DESCRIPTION
Apple updated the location of the App Store Credentials link, updating docs to reflect new location