### PR TITLE
Fixed link

### DIFF
--- a/docs/server-notifications/google-play.mdx
+++ b/docs/server-notifications/google-play.mdx
@@ -51,7 +51,7 @@ that topic. To create a subscription, do the following:
 2. Click on the **Create a subscription** button.
 3. Type the name of the subscription.
 4. Choose **Push to endpoint** as the delivery Type.
-5. Enter the [URL of the backend server](http://localhost:3000/laravel-iap-docs/docs/get-started/routing#generate-a-signed-url)
+5. Enter the [URL of the backend server](/docs/get-started/routing#generate-a-signed-url)
 you created in the **Endpoint URL**.
 6. Click on the **Create** button.
 


### PR DESCRIPTION
Currently it was pointing to http://localhost:3000/laravel-iap-docs/docs/get-started/routing#generate-a-signed-url