### PR TITLE
Add Alternative env GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/versioned_docs/version-1.x/credentials/google-play.mdx
+++ b/versioned_docs/version-1.x/credentials/google-play.mdx
@@ -30,9 +30,8 @@ you can set the credentials path via the `GOOGLE_APPLICATION_CREDENTIALS` enviro
 
 Example `.env` file:
 ```env
-GOOGLE_APPLICATION_CREDENTIALS=application_default_credentials.json
-```
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/application_default_credentials.json
+```
 ## Link your developer account
 
 Your Google Play Developer Account needs to be linked to Google Cloud Project.

--- a/versioned_docs/version-1.x/credentials/google-play.mdx
+++ b/versioned_docs/version-1.x/credentials/google-play.mdx
@@ -23,6 +23,16 @@ Rename the JSON key file `application_default_credentials.json` and place it in 
 - **windows**: `%APPDATA%/gcloud/application_default_credentials.json`
 - **others**: `$HOME/.config/gcloud/application_default_credentials.json`
 
+### Alternative: Use `.env`
+
+For some use cases (e.g., running under `supervisord`, Docker, or other environments where the default gcloud config path isn’t accessible),  
+you can set the credentials path via the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+
+Example `.env` file:
+```env
+GOOGLE_APPLICATION_CREDENTIALS=application_default_credentials.json
+```
+
 ## Link your developer account
 
 Your Google Play Developer Account needs to be linked to Google Cloud Project.

--- a/versioned_docs/version-1.x/credentials/google-play.mdx
+++ b/versioned_docs/version-1.x/credentials/google-play.mdx
@@ -32,7 +32,7 @@ Example `.env` file:
 ```env
 GOOGLE_APPLICATION_CREDENTIALS=application_default_credentials.json
 ```
-
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/application_default_credentials.json
 ## Link your developer account
 
 Your Google Play Developer Account needs to be linked to Google Cloud Project.


### PR DESCRIPTION
For some use cases (supervisord, Docker, or other environments where the default gcloud config path isn’t accessible)