### PR TITLE
Change receipt verification method for subscriptions for 1.x docs

### DIFF
--- a/versioned_docs/version-1.x/app-store/sell-subscriptions.mdx
+++ b/versioned_docs/version-1.x/app-store/sell-subscriptions.mdx
@@ -27,7 +27,7 @@ use Imdhemy\Purchases\Facades\Subscription;
 // Verifiy the receipt on App Store servers.
 // For non-renewable subscriptions, you can use the `verifyReceipt` method.
 // Subscription::appStore()->receiptData($receipt)->verifyReceipt();
-$receiptResponse = Subscription::appStore()->receiptData($receipt)->verify();
+$receiptResponse = Subscription::appStore()->receiptData($receipt)->verifyRenewable();
 
 // Get the receipt status
 $receiptStatus = $receiptResponse->getStatus();


### PR DESCRIPTION
update undefined verify( ) method to verifyRenewable( )